### PR TITLE
Add move and previous

### DIFF
--- a/docs/01-parsing-patterns.md
+++ b/docs/01-parsing-patterns.md
@@ -9,22 +9,35 @@ In cursornext, there are four basic functions that we would use frequently:
 
 ## Move
 
-To move the cursor, we can use `next` or `setIndex`. `next` move the cursor a number of characters. By using `next`, we can ensure that the cursor will move forward but not backward:
+To move the cursor, we can use `move`, `next`, `previous` or `setIndex`.
+
+`move` moves the cursor a number of characters.
+
+`next` is an alias of `move` that ensures that the cursor will only move forward. Default argument for move is 1.
+
+`previous` is an alias of `move` that ensures that the cursor will only move backward. Default argument for move is 1.
 
 ```ts
 const cursor = Cursor.from('Hello, World!')
+t.assert(cursor.index === 0)
 
-cursor.next(2)
-t.assert(cursor.index === 2)
+cursor.move(5)
+t.assert(cursor.index === 5)
 
 cursor.next(-1)
-t.assert(cursor.index === 2)
+t.assert(cursor.index === 5)
 
 cursor.next(2)
-t.assert(cursor.index === 4)
+t.assert(cursor.index === 7)
+
+cursor.previous(-1)
+t.assert(cursor.index === 7)
+
+cursor.previous() // default is 1
+t.assert(cursor.index === 6)
 ```
 
-Different from `next`, the `setIndex` method don't have the guaranteer that `next` method have:
+`setIndex` method lets you specify exact desired position for cursor:
 
 ```ts
 const cursor = Cursor.from('Hello, World!')
@@ -36,7 +49,7 @@ cursor.setIndex(3)
 t.assert(cursor.index === 3)
 ```
 
-But it can be very handful when working with regular expression:
+It can be very handful when working with regular expression:
 
 ```ts
 const cursor = Cursor.from('-----1996-----')

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -158,11 +158,23 @@ export class Cursor {
     this.setIndex(cursor.index)
   }
 
-  next(offset: number) {
+  next(offset: number = 1) {
     if (offset < 1) {
       return
     }
 
+    this.move(offset)
+  }
+
+  previous(offset: number = 1) {
+    if (offset < 1) {
+      return
+    }
+
+    this.move(-offset)
+  }
+
+  move(offset: number) {
     this.setIndex(this.index + offset)
   }
 


### PR DESCRIPTION
Hopefully solves [this issue](https://github.com/clitetailor/cursornext/issues/5).

Added `.move(n)` that moves cursor n characters and `.previous(n)` that moves it n characters back.

I also added default argument value of `1` to `.next` and `.previous` since for me it felt like an expected behaviour -- please tell me if you don't want that.